### PR TITLE
Reduce deb and war sizes

### DIFF
--- a/grill-client/pom.xml
+++ b/grill-client/pom.xml
@@ -19,9 +19,12 @@
       <version>${project.version}</version>
     </dependency>
     <dependency>
-      <groupId>com.inmobi.grill</groupId>
-      <artifactId>grill-server-api</artifactId>
-      <version>${project.version}</version>
+      <groupId>org.apache.hadoop</groupId>
+      <artifactId>hadoop-core</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>commons-logging</groupId>
+      <artifactId>commons-logging</artifactId>
     </dependency>
     <dependency>
       <groupId>com.inmobi.grill</groupId>

--- a/grill-client/src/main/java/com/inmobi/grill/client/GrillStatement.java
+++ b/grill-client/src/main/java/com/inmobi/grill/client/GrillStatement.java
@@ -21,9 +21,7 @@ package com.inmobi.grill.client;
  */
 
 import com.inmobi.grill.api.APIResult;
-import com.inmobi.grill.api.GrillConf;
 import com.inmobi.grill.api.query.*;
-import com.inmobi.grill.server.api.GrillConfConstants;
 import org.glassfish.jersey.media.multipart.FormDataBodyPart;
 import org.glassfish.jersey.media.multipart.FormDataContentDisposition;
 import org.glassfish.jersey.media.multipart.FormDataMultiPart;

--- a/grill-dist/pom.xml
+++ b/grill-dist/pom.xml
@@ -10,7 +10,6 @@
   </parent>
     
   <artifactId>grill-dist</artifactId>
-  <packaging>jar</packaging>
   <description> Packaging and distribution </description>
 
   <dependencies>
@@ -59,6 +58,10 @@
       <artifactId>grill-examples</artifactId>
       <version>${project.version}</version>
     </dependency>
+    <dependency>
+      <groupId>org.apache.hadoop</groupId>
+      <artifactId>hadoop-core</artifactId>
+    </dependency>
   </dependencies>
 
   <build>
@@ -83,15 +86,6 @@
           </execution>
         </executions>
       </plugin>
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-deploy-plugin</artifactId>
-        <version>2.7</version>
-        <configuration>
-          <skip>true</skip>
-        </configuration>
-      </plugin>
-
       <!--Plugin to build deb-->
       <plugin>
         <artifactId>jdeb</artifactId>

--- a/grill-dist/src/main/assembly/client-dist.xml
+++ b/grill-dist/src/main/assembly/client-dist.xml
@@ -53,15 +53,24 @@
       <unpack>false</unpack>
       <scope>runtime</scope>
       <outputDirectory>lib</outputDirectory>
-      <excludes>
-        <exclude>com.inmobi.grill:grill-server-api</exclude>      
-        <exclude>com.inmobi.grill:grill-driver-cube</exclude>
-        <exclude>com.inmobi.grill:grill-driver-hive</exclude>
-        <exclude>com.inmobi.grill:grill-driver-impala</exclude>
-        <exclude>com.inmobi.grill:grill-driver-jdbc</exclude>
-        <exclude>com.inmobi.grill:grill-dist</exclude>
-      </excludes>
+      <includes>
+        <include>com.inmobi.grill:grill-api</include>
+        <include>com.inmobi.grill:grill-cli</include>
+        <include>com.inmobi.grill:grill-client</include>
+        <include>com.inmobi.grill:grill-examples</include>
+      </includes>
+      <useTransitiveFiltering>true</useTransitiveFiltering>
+      <useTransitiveDependencies>true</useTransitiveDependencies>
     </dependencySet>
+    <dependencySet>
+      <unpack>false</unpack>
+      <scope>runtime</scope>
+      <outputDirectory>lib</outputDirectory>
+      <includes>
+        <include>org.apache.hadoop:hadoop-core</include>
+      </includes>
+    </dependencySet>
+
   </dependencySets>
 
   <fileSets>

--- a/grill-dist/src/main/assembly/server-dist.xml
+++ b/grill-dist/src/main/assembly/server-dist.xml
@@ -54,10 +54,6 @@
       <scope>runtime</scope>
       <outputDirectory>lib</outputDirectory>
       <includes>
-        <include>com.inmobi.grill:grill-api</include>
-        <include>com.inmobi.grill:grill-server-api</include>
-        <include>com.inmobi.grill:grill-driver-cube</include>
-        <include>com.inmobi.grill:grill-driver-hive</include>
         <include>com.inmobi.grill:grill-driver-jdbc</include>
         <include>com.inmobi.grill:grill-storage-db</include>
       </includes>

--- a/grill-examples/pom.xml
+++ b/grill-examples/pom.xml
@@ -25,14 +25,11 @@
       <version>${project.version}</version>
     </dependency>
 
-    <dependency>
-      <groupId>org.apache.hive</groupId>
-      <artifactId>hive-common</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>org.apache.hive</groupId>
-      <artifactId>hive-exec</artifactId>
-    </dependency>
+      <dependency>
+        <groupId>commons-lang</groupId>
+        <artifactId>commons-lang</artifactId>
+      </dependency>
+
   </dependencies>
 
 </project>    

--- a/grill-server/pom.xml
+++ b/grill-server/pom.xml
@@ -30,6 +30,14 @@
             <artifactId>hadoop-core</artifactId>
         </dependency>
         <dependency>
+            <groupId>org.apache.hive</groupId>
+            <artifactId>hive-exec</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.hive</groupId>
+            <artifactId>hive-service</artifactId>
+        </dependency>
+        <dependency>
             <groupId>javax.ws.rs</groupId>
             <artifactId>javax.ws.rs-api</artifactId>
         </dependency>
@@ -155,19 +163,11 @@
               </execution>
             </executions>
           </plugin>
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-deploy-plugin</artifactId>
-        <version>2.7</version>
-        <configuration>
-          <skip>true</skip>
-        </configuration>
-      </plugin>
-            <plugin>
+          <plugin>
                 <groupId>org.mortbay.jetty</groupId>
                 <artifactId>maven-jetty-plugin</artifactId>
                 <version>${jetty.version}</version>
-            </plugin>
+          </plugin>
             <plugin>
                 <groupId>org.codehaus.mojo</groupId>
                 <artifactId>exec-maven-plugin</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -305,6 +305,11 @@
         <version>1.1.1</version>
       </dependency>
       <dependency>
+        <groupId>commons-lang</groupId>
+        <artifactId>commons-lang</artifactId>
+        <version>2.4</version>
+      </dependency>
+      <dependency>
         <groupId>org.testng</groupId>
         <artifactId>testng</artifactId>
         <version>6.8</version>
@@ -314,6 +319,7 @@
         <groupId>org.apache.hive</groupId>
         <artifactId>hive-metastore</artifactId>
         <version>${hive.version}</version>
+        <scope>provided</scope>
       </dependency>
       <dependency>
         <groupId>org.apache.hadoop</groupId>
@@ -324,6 +330,14 @@
           <exclusion>
             <groupId>net.sf.kosmosfs</groupId>
             <artifactId>kfs</artifactId>
+          </exclusion>
+          <exclusion>
+            <groupId>com.cloudera.cdh</groupId>
+            <artifactId>hadoop-ant</artifactId>
+          </exclusion>
+          <exclusion>
+            <groupId>org.mortbay.jetty</groupId>
+            <artifactId>jetty</artifactId>
           </exclusion>
           <exclusion>
             <groupId>oro</groupId>
@@ -414,26 +428,31 @@
         <groupId>org.apache.hive</groupId>
         <artifactId>hive-common</artifactId>
         <version>${hive.version}</version>
+        <scope>provided</scope>
       </dependency>
       <dependency>
         <groupId>org.apache.hive</groupId>
         <artifactId>hive-exec</artifactId>
         <version>${hive.version}</version>
+        <scope>provided</scope>
       </dependency>
       <dependency>
         <groupId>org.apache.hive</groupId>
         <artifactId>hive-cli</artifactId>
         <version>${hive.version}</version>
+        <scope>provided</scope>
       </dependency>
       <dependency>
         <groupId>org.apache.hive</groupId>
         <artifactId>hive-service</artifactId>
         <version>${hive.version}</version>
+        <scope>provided</scope>
       </dependency>
        <dependency>
            <groupId>org.apache.hive</groupId>
            <artifactId>hive-shims</artifactId>
            <version>${hive.version}</version>
+           <scope>provided</scope>
            <exclusions>
              <exclusion>
                 <groupId>commons-logging</groupId>

--- a/tools/conf/grill-env.sh
+++ b/tools/conf/grill-env.sh
@@ -18,6 +18,12 @@
 # The java implementation to use. If JAVA_HOME is not found we expect java and jar to be in path
 #export JAVA_HOME=
 
+# The hadoop installation location. If Grill is configured to run queries through Hive, which in turn uses Hadoop for execution, the variable is required
+#export HADOOP_HOME=
+
+# The Hive installation location. Grill adds hive lib in the classpath.
+#export HIVE_HOME=
+
 # any additional java opts you want to set. This will apply to both client and server operations
 #export GRILL_OPTS=
 

--- a/tools/scripts/grill-ctl
+++ b/tools/scripts/grill-ctl
@@ -87,17 +87,20 @@ start() {
   HADOOPDIR=`which hadoop`
   if [ "$HADOOPDIR" != "" ]; then  
     echo "Hadoop is installed, using the installed hadoop for execution"
-#   echo "Hadoop is installed, adding hadoop classpath to grill classpath"
-#   GRILLCPPATH="${GRILLCPPATH}:`hadoop classpath`"
   elif [ "$HADOOP_HOME" != "" ]; then    
     echo "Hadoop home is set, using the configured hadoop for execution"
-#   echo "Hadoop home is set, adding ${HADOOP_HOME}/lib/* into grill classpath"
-#   GRILLCPPATH="${GRILLCPPATH}:${HADOOP_HOME}/lib/*"
   else
-    echo "Could not find installed hadoop and HADOOP_HOME is not set."
-    exit 1
+    echo "WARNING : Could not find installed hadoop and HADOOP_HOME is not set. If Hadoop is used execution of queries. Set HADOOP_HOME and proceed"
   fi
 
+  if [ "$HIVE_HOME" != "" ]; then    
+    echo "HIVE_HOME is set, adding ${HIVE_HOME}/lib/* into grill classpath"
+    GRILLCPPATH="${GRILLCPPATH}:${HIVE_HOME}/lib/*"
+  else
+    echo "HIVE_HOME is not set. Set HIVE_HOME and try again"
+    exit 1
+  fi
+  
   mkdir -p $GRILL_LOG_DIR
 
   JAVA_PROPERTIES="${JAVA_PROPERTIES} $GRILL_OPTS $GRILL_PROPERTIES -Dgrill.log.dir=$GRILL_LOG_DIR -Dgrill.home=${GRILL_HOME_DIR} -Dconfig.location=$GRILL_CONF"


### PR DESCRIPTION
Makes hive packing to provided. Did not make hadoop packaging to provided, because we need only hadoop-core.jar and have to skip everything else. We cannot put HADOOP_HOME/lib directly because the many jars would clash. So, right now bundling hadoop-core jar in the packages.

No HADOOP_HOME or HIVE_HOME is required for client package.

Newer sizes are : 
13M  grill-client_1.0.0-SNAPSHOT.deb
45M  grill-server_1.0.0-SNAPSHOT.deb
22M  grill-server-1.0.0-SNAPSHOT.war
