### PR TITLE
Switch Order of Driver Selection

### DIFF
--- a/grill-driver-hive/src/main/java/com/inmobi/grill/driver/hive/HiveQueryPlan.java
+++ b/grill-driver-hive/src/main/java/com/inmobi/grill/driver/hive/HiveQueryPlan.java
@@ -194,9 +194,11 @@ public class HiveQueryPlan extends DriverQueryPlan {
 
 	@Override
 	public QueryCost getCost() {
-    //Returning default 0 as min cost which is equal to rule in case multiple
-    //storages are present hive storage is always selected.
-		return new QueryCost(0,0);
+    /*
+    Return query cost as 1 so that if JDBC storage and storage is present,
+    JDBC is given preference.
+     */
+		return new QueryCost(1,1);
 	}
 
   @Override

--- a/grill-driver-jdbc/src/main/java/com/inmobi/grill/driver/jdbc/JDBCDriver.java
+++ b/grill-driver-jdbc/src/main/java/com/inmobi/grill/driver/jdbc/JDBCDriver.java
@@ -329,7 +329,7 @@ public class JDBCDriver implements GrillDriver {
     @Override
     public QueryCost getCost() {
       //this means that JDBC driver is only selected for tables with just DB storage.
-      return new QueryCost(1L, 1);
+      return new QueryCost(0, 0);
     }
   }
 


### PR DESCRIPTION
Switching order of driver selection. Now JDBC is chosen over for queries in which storage is available on both Database and Hadoop.
