### PR TITLE
Setting the bean dependency for the GrillDimensionTableCommand

### DIFF
--- a/grill-cli/src/main/resources/META-INF/spring/spring-shell-plugin.xml
+++ b/grill-cli/src/main/resources/META-INF/spring/spring-shell-plugin.xml
@@ -59,4 +59,8 @@
     <property name="client" ref="client"/>
   </bean>
 
+  <bean id="grillDimensionTableCommands"
+        class="com.inmobi.grill.cli.commands.GrillDimensionTableCommands">
+    <property name="client" ref="client"/>
+  </bean>
 </beans>


### PR DESCRIPTION
Modified the spring-shell-plugin.xml to inject dependency.
