### PR TITLE
Adding launch time on query execution statistics.

### DIFF
--- a/grill-server/src/main/java/com/inmobi/grill/server/query/QueryExecutionStatisticsGenerator.java
+++ b/grill-server/src/main/java/com/inmobi/grill/server/query/QueryExecutionStatisticsGenerator.java
@@ -62,6 +62,7 @@ public class QueryExecutionStatisticsGenerator extends AsyncEventListener<QueryE
       return;
     }
     event.setEndTime(ctx.getEndTime());
+    event.setStartTime(ctx.getLaunchTime());
     event.setStatus(ctx.getStatus());
     event.setCause(ended.getCause() != null ? ended.getCause() : "");
     event.setResult(ctx.getResultSetPath());

--- a/tools/conf/server/log4j.properties
+++ b/tools/conf/server/log4j.properties
@@ -61,6 +61,6 @@ log4j.appender.STATUS.MaxBackupIndex=20
 
 #Add query statistics logger with hourly rollup
 log4j.appender.QueryExecutionStatistics=org.apache.log4j.DailyRollingFileAppender
-log4j.appender.QueryExecutionStatistics.DatePattern='.'yyyy-MM-dd-HH-mm
+log4j.appender.QueryExecutionStatistics.DatePattern='.'yyyy-MM-dd-HH
 log4j.appender.QueryExecutionStatistics.File=${grill.log.dir}/query-stats.log
 log4j.appender.QueryExecutionStatistics.layout=com.inmobi.grill.server.stats.store.log.StatisticsLogLayout


### PR DESCRIPTION
- Adding launch time to query execution statistics.
- Changing rollup interval to hourly instead of minutely currently.
